### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -24,38 +24,73 @@
   "targetDefaults": {
     "test:knip": {
       "cache": true,
-      "inputs": ["{workspaceRoot}/**/*"]
+      "inputs": [
+        "{workspaceRoot}/**/*"
+      ]
     },
     "test:sherif": {
       "cache": true,
-      "inputs": ["{workspaceRoot}/**/package.json"]
+      "inputs": [
+        "{workspaceRoot}/**/package.json"
+      ]
     },
     "test:eslint": {
       "cache": true,
-      "dependsOn": ["^build"],
-      "inputs": ["default", "^production", "{workspaceRoot}/eslint.config.js"]
+      "dependsOn": [
+        "^build"
+      ],
+      "inputs": [
+        "default",
+        "^production",
+        "{workspaceRoot}/eslint.config.js"
+      ]
     },
     "test:lib": {
       "cache": true,
-      "dependsOn": ["^build"],
-      "inputs": ["default", "^production"],
-      "outputs": ["{projectRoot}/coverage"]
+      "dependsOn": [
+        "^build"
+      ],
+      "inputs": [
+        "default",
+        "^production"
+      ],
+      "outputs": [
+        "{projectRoot}/coverage"
+      ]
     },
     "test:types": {
       "cache": true,
-      "dependsOn": ["^build"],
-      "inputs": ["default", "^production"]
+      "dependsOn": [
+        "^build"
+      ],
+      "inputs": [
+        "default",
+        "^production"
+      ]
     },
     "build": {
       "cache": true,
-      "dependsOn": ["^build"],
-      "inputs": ["production", "^production"],
-      "outputs": ["{projectRoot}/build", "{projectRoot}/dist"]
+      "dependsOn": [
+        "^build"
+      ],
+      "inputs": [
+        "production",
+        "^production"
+      ],
+      "outputs": [
+        "{projectRoot}/build",
+        "{projectRoot}/dist"
+      ]
     },
     "test:build": {
       "cache": true,
-      "dependsOn": ["build"],
-      "inputs": ["production"]
+      "dependsOn": [
+        "build"
+      ],
+      "inputs": [
+        "production"
+      ]
     }
-  }
+  },
+  "nxCloudId": "6764b30fd3d5277eca5a010d"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace 
    
This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to 
https://cloud.nx.app/orgs/6764b0057d3014e5885951f5/workspaces/6764b30fd3d5277eca5a010d

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.